### PR TITLE
Update the snowflake plugin to support feast version 0.17

### DIFF
--- a/feast_snowflake/snowflake_online.py
+++ b/feast_snowflake/snowflake_online.py
@@ -8,13 +8,12 @@ import pytz
 from pydantic.schema import Literal
 from pydantic import Field
 
-from feast import Entity, FeatureTable
-from feast.feature_view import DUMMY_ENTITY_ID, DUMMY_ENTITY_VAL, FeatureView
+from feast import Entity
+from feast.feature_view import FeatureView
 from feast.infra.online_stores.online_store import OnlineStore
 from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
 from feast.protos.feast.types.Value_pb2 import Value as ValueProto
 from feast.repo_config import FeastConfigBaseModel, RepoConfig
-from feast.type_map import feast_value_type_to_python_type, python_value_to_proto_value
 from feast.usage import log_exceptions_and_usage
 
 from feast.infra.key_encoding_utils import serialize_entity_key
@@ -69,7 +68,7 @@ class SnowflakeOnlineStore(OnlineStore):
     def online_write_batch(
         self,
         config: RepoConfig,
-        table: Union[FeatureTable, FeatureView],
+        table: FeatureView,
         data: List[
             Tuple[EntityKeyProto, Dict[str, ValueProto], datetime, Optional[datetime]]
         ],
@@ -140,7 +139,7 @@ class SnowflakeOnlineStore(OnlineStore):
     def online_read(
         self,
         config: RepoConfig,
-        table: Union[FeatureTable, FeatureView],
+        table: FeatureView,
         entity_keys: List[EntityKeyProto],
         requested_features: Optional[List[str]] = None,
     ) -> List[Tuple[Optional[datetime], Optional[Dict[str, ValueProto]]]]:
@@ -189,8 +188,8 @@ class SnowflakeOnlineStore(OnlineStore):
     def update(
         self,
         config: RepoConfig,
-        tables_to_delete: Sequence[Union[FeatureTable, FeatureView]],
-        tables_to_keep: Sequence[Union[FeatureTable, FeatureView]],
+        tables_to_delete: Sequence[FeatureView],
+        tables_to_keep: Sequence[FeatureView],
         entities_to_delete: Sequence[Entity],
         entities_to_keep: Sequence[Entity],
         partial: bool,
@@ -220,7 +219,7 @@ class SnowflakeOnlineStore(OnlineStore):
     def teardown(
         self,
         config: RepoConfig,
-        tables: Sequence[Union[FeatureTable, FeatureView]],
+        tables: Sequence[FeatureView],
         entities: Sequence[Entity],
     ):
         assert isinstance(config.online_store, SnowflakeOnlineStoreConfig)

--- a/feast_snowflake/snowflake_utils.py
+++ b/feast_snowflake/snowflake_utils.py
@@ -351,7 +351,7 @@ def get_snowflake_conn(config) -> SnowflakeConnection:
             schema=f'''"{kwargs['schema_']}"''',
             application="feast",
             autocommit=False,)
-            
+
         return conn
     except KeyError as e:
         print(f'{e} not defined in a config file or feature_store.yaml file')


### PR DESCRIPTION
### Summary

- Update the offline store to support changes on feast version 0.17
- Remove the unused classes from online store 

### Test
- Tested the changes to work with Feast version 0.17 and Snowflake as offline store